### PR TITLE
Fix configure script for ncurses without ncursesw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,9 @@ if test -n "$PKG_CONFIG"; then
             [
                 NCURSES_WIDECHAR_SUPPORT="no"
                 PKG_CHECK_MODULES([NCURSES], [ncurses],
-                    [],
+                    [
+                        NCURSES_FOUND="yes"
+                    ],
                     [
                         AC_MSG_WARN([$NCURSES_PKG_ERRORS])
                     ])


### PR DESCRIPTION
On debian systems it is possible not to have libncursesw5-dev and
still have ncursesw5-config pointing to where it should be,
ncursesw5-config is provided by libncursesw5.
