### PR TITLE
Fix for the "bad character" when doing backspace in chat window

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -242,7 +242,7 @@ void draw_active_window(Tox *m)
 
     /* Handle input */
 #ifdef HAVE_WIDECHAR
-    get_wch(&ch);
+    wget_wch(a->window, &ch);
 #else
     ch = getch();
 #endif


### PR DESCRIPTION
Backspace was printing 'ć' instead of actually backspacing in a chat
window when widechar support was enabled.
