### PR TITLE
Make sure toxic compiles on MinGW/Win32 again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,8 @@ if test "x$NCURSES_FOUND" = "xno"; then
                 AC_MSG_ERROR([required library winsock2 was not found on the system, please check your MinGW installation])
             ]
         )
+        AC_DEFINE([_WIN32_WINNT], [0x501],
+                  [enable getaddrinfo/freeaddrinfo on XP and higher])
     else
         AC_CHECK_LIB([ncursesw], [wget_wch],
             [

--- a/src/configdir.c
+++ b/src/configdir.c
@@ -49,7 +49,10 @@
 char *get_user_config_dir(void)
 {
     char *user_config_dir;
-#ifdef WIN32
+#ifdef __WIN32__
+#warning Please fix configdir for Win32
+    return NULL;
+#if 0
     char appdata[MAX_PATH];
     BOOL ok;
 
@@ -62,6 +65,7 @@ char *get_user_config_dir(void)
     user_config_dir = strdup(appdata);
 
     return user_config_dir;
+#endif
 
 #else /* WIN32 */
 
@@ -126,11 +130,10 @@ char *get_user_config_dir(void)
  */
 int create_user_config_dir(char *path)
 {
-
-    int mkdir_err;
-
-#ifdef WIN32
-
+#ifdef __WIN32__
+#warning Please fix configdir for Win32
+    return -1;
+#if 0
     char *fullpath = malloc(strlen(path) + strlen(CONFIGDIR) + 1);
     strcpy(fullpath, path);
     strcat(fullpath, CONFIGDIR);
@@ -143,7 +146,11 @@ int create_user_config_dir(char *path)
         return -1;
     }
 
+    free(fullpath);
+#endif
+
 #else
+    int mkdir_err;
 
     mkdir_err = mkdir(path, 0700);
     struct stat buf;
@@ -163,7 +170,7 @@ int create_user_config_dir(char *path)
         return -1;
     }
 
-#endif
     free(fullpath);
     return 0;
+#endif
 }


### PR DESCRIPTION
This PR makes toxic compile on MinGW/Win32 with pdcurses. That being said - it does not fix all the problems that exist, it just makes sure you can compile.

So what's still broken? 
- the "configdir" stuff won't compile at all if enabled
- each second a weird character is printed in the prompt, so you really have to be fast if you want to enter a command

I did not have the nerve or motivation to look into the above issues, since I actually ended up fixing the winblows build by accident while debugging a different problem. Hope some of the windowers can pick it up from here :P
