### PR TITLE
fixed "free(): invalid pointer" when XDG_CONFIG_HOME is set

### DIFF
--- a/src/configdir.c
+++ b/src/configdir.c
@@ -107,7 +107,8 @@ char *get_user_config_dir(void)
     snprintf(user_config_dir, len, "%s/Library/Application Support", home);
 # else /* __APPLE__ */
 
-    if (!(user_config_dir = getenv("XDG_CONFIG_HOME"))) {
+    const char *tmp;
+    if (!(tmp = getenv("XDG_CONFIG_HOME"))) {
         len = strlen(home) + strlen("/.config") + 1;
         user_config_dir = malloc(len);
 
@@ -116,6 +117,8 @@ char *get_user_config_dir(void)
         }
 
         snprintf(user_config_dir, len, "%s/.config", home);
+    } else {
+        user_config_dir = strdup(tmp);
     }
 
 # endif /* __APPLE__ */


### PR DESCRIPTION
Quote from the `getenv` man page: "As typically implemented, getenv() returns a pointer to a string within the environment list.  The caller must take care **not to modify this string**, since that would change the environment of the process." And otherwise it fails:

```
*** Error in `[...]/toxic/build/toxic': free(): invalid pointer: 0x00007fffffffef93 ***
======= Backtrace: =========
/usr/lib/libc.so.6(+0x72ecf)[0x7ffff73e3ecf]
/usr/lib/libc.so.6(+0x7869e)[0x7ffff73e969e]
/usr/lib/libc.so.6(+0x79377)[0x7ffff73ea377]
[...]/toxic/build/toxic[0x402436]
/usr/lib/libc.so.6(__libc_start_main+0xf5)[0x7ffff7392bc5]
[...]/toxic/build/toxic[0x402ae9]
======= Memory map: ========
...
```
