### PR TITLE
Fix blocking while waiting for key

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -239,7 +239,7 @@ void draw_active_window(Tox *m)
 
     /* Handle input */
 #ifdef HAVE_WIDECHAR
-    wget_wch(a->window, &ch);
+    wget_wch(stdscr, &ch);
 #else
     ch = getch();
 #endif


### PR DESCRIPTION
The timeout() for input is set on main window (stdscr), since it seems
that for some ncurses implementations get_wch and getch are the same
(non widechar) wget_wch is used instead. The window passed must the
the main one, the others doesn't have the timeout settings. Another
option is to set wtimeout() on every window.
