### PR TITLE
Do not reset input buffer on close

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -238,8 +238,10 @@ static void chat_onKey(ToxWindow *self, Tox *m, wint_t key)
             }
         }
 
-        ctx->line[0] = L'\0';
-        ctx->pos = 0;
+        if (strncmp(line, "/close", strlen("/close"))) {
+            ctx->line[0] = L'\0';
+            ctx->pos = 0;
+        }
         free(line);
     }
 }


### PR DESCRIPTION
When chat window is closed the context buffer gets destroyed before
the reseting the buffer. This avoids invalid write.
