### PR TITLE
Let windows.c actually get the tox *m.

### DIFF
--- a/src/windows.c
+++ b/src/windows.c
@@ -195,8 +195,9 @@ void set_active_window(int index)
     active_window = windows + index;
 }
 
-ToxWindow *init_windows()
+ToxWindow *init_windows(Tox *mToAssign)
 {
+    m = mToAssign;
     int n_prompt = add_window(m, new_prompt());
 
     if (n_prompt == -1 || add_window(m, new_friendlist()) == -1) {


### PR DESCRIPTION
main.c called init_windows(m), but windows.c only had init_windows(). This caused m to be NULL, which didn't cause any crashes, but it was certainly a headache for trying to do some new stuff.

For instance I was calling tox_addfriend_norequest() in windows.c:on_request() to auto-add friends. It kept crashing on me since the global var Tox *m was never assigned anything.
