### PR TITLE
Fix trailing slashes which leads to segfault.

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -205,6 +205,11 @@ static void chat_onFileData(ToxWindow *self, Tox *m, int num, uint8_t filenum, u
     uint8_t *filename = friends[num].file_receiver.filenames[filenum];
     FILE *file_to_save = fopen(filename, "a");
 
+     // we have a problem here, but don't let it segfault
+    if (file_to_save == NULL) {
+        return;
+    }
+
     if (fwrite(data, length, 1, file_to_save) != 1) {
         wattron(ctx->history, COLOR_PAIR(RED));
         wprintw(ctx->history, "* Error writing to file.\n");


### PR DESCRIPTION
When filename has trailing slashes, say '/path/to/a/dir/', the current implementation will failed to detect this case and set the filename to '/path/to/a/dir/' instead of 'dir', which will lead to segfault in chat_onFileData.
