### PR TITLE
umask such that stored files are u+rw only

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -470,6 +470,9 @@ int main(int argc, char *argv[])
     int i = 0;
     int f_use_ipv4 = 0;
 
+    // Make sure all written files are read/writeable only by the current user.
+    umask(S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+
     for (i = 0; i < argc; ++i) {
         if (argv[i] == NULL)
             break;


### PR DESCRIPTION
Specifically the data file should not be read/writable to group/other since it contains the private key.

There are more surgical ways this can be done (chmod'ing in `store_data`), but I don't think there is a downside to being overly protective in this way.
