### PR TITLE
Include "pthread.h"

### DIFF
--- a/src/toxic_windows.h
+++ b/src/toxic_windows.h
@@ -28,6 +28,7 @@
 #endif
 
 #include <curses.h>
+#include <pthread.h>
 #include <wctype.h>
 #include <wchar.h>
 


### PR DESCRIPTION
It isn't implicit on OpenBSD.
