### PR TITLE
Drop typedef redeclarations

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -6,8 +6,8 @@
 #include "config.h"
 #endif
 
-#include "audio_call.h"
 #include "toxic_windows.h"
+#include "audio_call.h"
 #include "chat_commands.h"
 #include "global_commands.h"
 #include "toxic_windows.h"

--- a/src/audio_call.h
+++ b/src/audio_call.h
@@ -7,8 +7,6 @@
 
 #include <tox/toxav.h>
 
-typedef struct ToxWindow ToxWindow;
-
 typedef enum _AudioError
 {
     NoError = 0,


### PR DESCRIPTION
C99 doesn't permit redeclaring typedefs in the same scope.
