### PR TITLE
Use long int instead uint64_t

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -93,7 +93,8 @@ endif
 all: toxic
 
 toxic: $(OBJ)
-	$(CC) $(CFLAGS) -o toxic $(OBJ) $(LDFLAGS)
+	@echo "  LD    $@"
+	@$(CC) $(CFLAGS) -o toxic $(OBJ) $(LDFLAGS)
 
 install: toxic
 	mkdir -p $(abspath $(DESTDIR)/$(BINDIR))
@@ -117,8 +118,9 @@ install: toxic
 	done
 
 %.o: $(SRC_DIR)/%.c
-	$(CC) $(CFLAGS) -o $*.o -c $(SRC_DIR)/$*.c
-	$(CC) -MM $(CFLAGS) $(SRC_DIR)/$*.c > $*.d
+	@echo "  CC    $@"
+	@$(CC) $(CFLAGS) -o $*.o -c $(SRC_DIR)/$*.c
+	@$(CC) -MM $(CFLAGS) $(SRC_DIR)/$*.c > $*.d
 
 clean:
 	rm -rf *.d *.o toxic

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -73,9 +73,9 @@ void get_elapsed_time_str(char *buf, int bufsize, uint64_t secs)
     if (!secs)
         return;
 
-    uint64_t seconds = secs % 60;
-    uint64_t minutes = (secs % 3600) / 60;
-    uint64_t hours = secs / 3600;
+    long int seconds = secs % 60;
+    long int minutes = (secs % 3600) / 60;
+    long int hours = secs / 3600;
 
     if (!minutes && !hours)
         snprintf(buf, bufsize, "%.2ld", seconds);


### PR DESCRIPTION
This should prevent

```
../src/misc_tools.c: In function ‘get_elapsed_time_str’:
../src/misc_tools.c:81:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:81:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:83:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:83:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:83:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:83:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:85:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:85:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:85:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 6 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:85:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:85:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘uint64_t’ [-Wformat]
../src/misc_tools.c:85:9: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 6 has type ‘uint64_t’ [-Wformat]
```
