### PR TITLE
Makefile: revert back to mkdir

### DIFF
--- a/cfg/targets/install.mk
+++ b/cfg/targets/install.mk
@@ -1,29 +1,35 @@
 # Install target
 install: toxic
 	@echo "Installing toxic executable"
-	@install -Dm 0755 toxic $(abspath $(DESTDIR)/$(BINDIR)/toxic)
+	@mkdir -p $(abspath $(DESTDIR)/$(BINDIR))
+	@install -m 0755 toxic $(abspath $(DESTDIR)/$(BINDIR)/toxic)
 
 	@echo "Installing desktop file"
-	@install -Dm 0644 $(MISC_DIR)/$(DESKFILE) $(abspath $(DESTDIR)/$(APPDIR)/$(DESKFILE))
+	@mkdir -p $(abspath $(DESTDIR)/$(APPDIR))
+	@install -m 0644 $(MISC_DIR)/$(DESKFILE) $(abspath $(DESTDIR)/$(APPDIR)/$(DESKFILE))
 
 	@echo "Installing data files"
+	@mkdir -p $(abspath $(DESTDIR)/$(DATADIR))
 	@for f in $(DATAFILES) ; do \
-		install -Dm 0644 $(MISC_DIR)/$$f $(abspath $(DESTDIR)/$(DATADIR)/$$f) ;\
+		install -m 0644 $(MISC_DIR)/$$f $(abspath $(DESTDIR)/$(DATADIR)/$$f) ;\
 		file=$(abspath $(DESTDIR)/$(DATADIR)/$$f) ;\
 		sed -i'' -e 's:__DATADIR__:'$(abspath $(DATADIR))':g' $$file ;\
 	done
+	@mkdir -p $(abspath $(DESTDIR)/$(DATADIR))/sounds
 	@for f in $(SNDFILES) ; do \
-		install -Dm 0644 $(SND_DIR)/$$f $(abspath $(DESTDIR)/$(DATADIR)/sounds/$$f) ;\
+		install -m 0644 $(SND_DIR)/$$f $(abspath $(DESTDIR)/$(DATADIR)/sounds/$$f) ;\
 	done
 
 	@echo "Installing man pages"
+	@mkdir -p $(abspath $(DESTDIR)/$(MANDIR))
 	@for f in $(MANFILES) ; do \
 		if [ ! -e "$$f" ]; then \
 			continue ;\
 		fi ;\
 		section=$(abspath $(DESTDIR)/$(MANDIR))/man`echo $$f | rev | cut -d "." -f 1` ;\
 		file=$$section/$$f ;\
-		install -Dm 0644 $(DOC_DIR)/$$f $$file ;\
+		mkdir -p $$section ;\
+		install -m 0644 $(DOC_DIR)/$$f $$file ;\
 		sed -i'' -e 's:__VERSION__:'$(VERSION)':g' $$file ;\
 		sed -i'' -e 's:__DATADIR__:'$(abspath $(DATADIR))':g' $$file ;\
 		gzip -f -9 $$file ;\


### PR DESCRIPTION
Just found out that `install -D` isn't portable.
