### PR TITLE
Destroy AL context before closing dhndl

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -323,9 +323,9 @@ DeviceError close_device(DeviceType type, uint32_t device_idx)
             alDeleteSources(1, &device->source);
             alDeleteBuffers(OPENAL_BUFS, device->buffers);
             
-            if ( !alcCloseDevice(device->dhndl) ) rc = de_AlError;
             alcMakeContextCurrent(NULL);
             if ( device->ctx ) alcDestroyContext(device->ctx);
+            if ( !alcCloseDevice(device->dhndl) ) rc = de_AlError;
         }
         
         free(device);


### PR DESCRIPTION
fixes seggy on os x, i think

ref #259
