### PR TITLE
Made the keys section of settings_load more readable in settings.c

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -299,16 +299,26 @@ int settings_load(struct user_settings *s, const char *patharg)
 	/* keys */
 	if ((setting = config_lookup(cfg, key_strings.self)) != NULL) {
 	   const char* tmp = NULL;
-	   if (config_setting_lookup_string(setting, key_strings.next_tab, &tmp)) s->key_next_tab = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.prev_tab, &tmp)) s->key_prev_tab = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.scroll_line_up, &tmp)) s->key_scroll_line_up = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.scroll_line_down, &tmp)) s->key_scroll_line_down= key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.half_page_up, &tmp)) s->key_half_page_up = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.half_page_down, &tmp)) s->key_half_page_down = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.page_bottom, &tmp)) s->key_page_bottom = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.peer_list_up, &tmp)) s->key_peer_list_up = key_parse(&tmp);
-	   if (config_setting_lookup_string(setting, key_strings.peer_list_down, &tmp)) s->key_peer_list_down = key_parse(&tmp);
-       if (config_setting_lookup_string(setting, key_strings.toggle_peerlist, &tmp)) s->key_toggle_peerlist = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.next_tab, &tmp))
+		   s->key_next_tab = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.prev_tab, &tmp))
+		   s->key_prev_tab = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.scroll_line_up, &tmp))
+		   s->key_scroll_line_up = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.scroll_line_down, &tmp))
+		   s->key_scroll_line_down= key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.half_page_up, &tmp))
+		   s->key_half_page_up = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.half_page_down, &tmp))
+		   s->key_half_page_down = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.page_bottom, &tmp))
+		   s->key_page_bottom = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.peer_list_up, &tmp))
+		   s->key_peer_list_up = key_parse(&tmp);
+	   if (config_setting_lookup_string(setting, key_strings.peer_list_down, &tmp))
+		   s->key_peer_list_down = key_parse(&tmp);
+       if (config_setting_lookup_string(setting, key_strings.toggle_peerlist, &tmp))
+	       s->key_toggle_peerlist = key_parse(&tmp);
 	}	   
 
 #ifdef AUDIO


### PR DESCRIPTION
Just made the keys section of the code a little bit more readable.

Probably not necessary at all since the semantics are the same:

Compiled and ran on Ubuntu 14.04 on an amd64 architecture.

$ uname -a
Linux ThinkPad-T440s 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
