### PR TITLE
Fix DNS naming | 'tox#' → 'toxdns#'

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -44,7 +44,7 @@
 
 #define DNS3_KEY_SIZE 32
 #define MAX_DNS_REQST_SIZE 255
-#define TOX_DNS3_TXT_PREFIX "v=tox3;id="
+#define TOX_DNS3_TXT_PREFIX "v=toxdns3;id="
 
 extern struct Winthread Winthread;
 extern struct dns3_servers dns3_servers;


### PR DESCRIPTION
Depends on:
- toxcore PR: https://github.com/irungentoo/toxcore/pull/1309
- toxme.se PR: https://github.com/Tox/toxme.se/pull/26
- utox.org PR: https://github.com/notsecure/tox-dns/pull/1
- Tox-QuickDNS PR: https://github.com/Tox/Tox-QuickDNS/pull/2
- STS PR: https://github.com/Tox/Tox-STS/pull/48
- STS PR:
