### PR TITLE
Change max avatar size to 256kB

### DIFF
--- a/src/avatars.h
+++ b/src/avatars.h
@@ -23,7 +23,7 @@
 #ifndef AVATARS_H
 #define AVATARS_H
 
-#define MAX_AVATAR_FILE_SIZE 65536
+#define MAX_AVATAR_FILE_SIZE 262144
 
 /* Sends avatar to friendnum.
  *


### PR DESCRIPTION
Otherwise small avatars look bad in clients that display them on bigger
surfaces, e.g. Antox.

Patch needed for time being, in future there might be a switch to webp, which should make it possible to have avatars that are looking ~well even with really small size.

For details, look at related IRC chat: https://gist.github.com/zetok/6204b08ddda5a27b60be

Related PRs in other clients:
- https://github.com/tux3/qTox/pull/1759
