### PR TITLE
Fix save data failing to save

### DIFF
--- a/src/toxic.c
+++ b/src/toxic.c
@@ -550,6 +550,10 @@ int store_data(Tox *m, const char *path)
         return -1;
 
     path_len=strlen(path);
+    if (path_len+sizeof(".tmp") > FILENAME_MAX) {
+        fprintf(stderr, "store_data() temp filename is too long\n");
+        return -1;
+    }
     //Place temporary file in same directory as file located in path
     memcpy(temp_path, path, path_len);
     memcpy(temp_path+path_len, ".tmp", sizeof(".tmp"));


### PR DESCRIPTION
Now it places temporary file in same folder as the save's one. Fixes case(s), where rename() fails for some reason. In my case data file was in symlinked folder that is located in different disc, while toxic was launched not from disc where data file was located.
