### PR TITLE
Fix #372 - can't start with missing ~/.config

### DIFF
--- a/src/configdir.c
+++ b/src/configdir.c
@@ -99,11 +99,6 @@ char *get_user_config_dir(void)
 
 # endif /* __APPLE__ */
 
-    if (!file_exists(user_config_dir)) {
-        free(user_config_dir);
-        return NULL;
-    }
-
     return user_config_dir;
 }
 


### PR DESCRIPTION
This block was added in fa0e645. I'm unsure what bug or corner case it
was intended to address but it causes Toxic to exit with an error if
the ~/.config directory doesn't exist. Without this block the ~/.config
directory and tox-specific subdirectories will be created when Toxic
starts.
