### PR TITLE
Add password_eval option to skip password prompt

### DIFF
--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -123,6 +123,10 @@ OPTIONS
     *chatlogs_path*;;
         Default path for chatlogs. String value. Absolute path for chatlog files.
 
+    *password_eval*;;
+        Replace password prompt by running this command and using its output as
+	the password.
+
 *sounds*::
     Configuration related to notification sounds.
     Special value "silent" can be used to disable a specific notification. +

--- a/src/settings.c
+++ b/src/settings.c
@@ -158,11 +158,13 @@ static const struct tox_strings {
     const char* download_path;
     const char* chatlogs_path;
     const char* avatar_path;
+    const char* password_eval;
 } tox_strings = {
     "tox",
     "download_path",
     "chatlogs_path",
     "avatar_path",
+    "password_eval",
 };
 
 static void tox_defaults(struct user_settings* settings)
@@ -170,6 +172,7 @@ static void tox_defaults(struct user_settings* settings)
     strcpy(settings->download_path, "");
     strcpy(settings->chatlogs_path, "");
     strcpy(settings->avatar_path, "");
+    strcpy(settings->password_eval, "");
 }
 
 #ifdef AUDIO
@@ -358,6 +361,14 @@ int settings_load(struct user_settings *s, const char *patharg)
 
             if (len >= sizeof(s->avatar_path))
                 s->avatar_path[0] = '\0';
+        }
+
+        if ( config_setting_lookup_string(setting, tox_strings.password_eval, &str) ) {
+            snprintf(s->password_eval, sizeof(s->password_eval), "%s", str);
+            int len = strlen(str);
+
+            if (len >= sizeof(s->password_eval))
+                s->password_eval[0] = '\0';
         }
     }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,6 +30,8 @@
 /* Represents line_* hints max strlen */
 #define LINE_HINT_MAX 3
 
+#define PASSWORD_EVAL_MAX 512
+
 /* holds user setting values */
 struct user_settings {
     int autolog;           /* boolean */
@@ -53,6 +55,7 @@ struct user_settings {
     char download_path[PATH_MAX];
     char chatlogs_path[PATH_MAX];
     char avatar_path[PATH_MAX];
+    char password_eval[PASSWORD_EVAL_MAX];
 
     int key_next_tab;
     int key_prev_tab;


### PR DESCRIPTION
Runs a command and uses its output as the password. This can be used for
getting the password from a password manager such as pass.
