### PR TITLE
Update misc_tools.c

### DIFF
--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -26,11 +26,13 @@
 #include <time.h>
 #include <limits.h>
 #include <dirent.h>
+#if defined(__FreeBSD__)
 #include <netinet/in.h>
 #include <sys/socket.h>
-
-#include <sys/stat.h>
+#else
 #include <arpa/inet.h>
+#endif
+#include <sys/stat.h>
 
 #include "toxic.h"
 #include "windows.h"

--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -26,6 +26,8 @@
 #include <time.h>
 #include <limits.h>
 #include <dirent.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
 #include <sys/stat.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Fix build on FreeBSD with clang.

Without this patch, compilation fails with these messages:

  CC    misc_tools.o
/usr/ports/net-im/toxic/work/toxic-0.7.1/src/misc_tools.c:479:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in s_addr;
                       ^
/usr/ports/net-im/toxic/work/toxic-0.7.1/src/misc_tools.c:479:12: note: forward declaration of 'struct sockaddr_in'
    struct sockaddr_in s_addr;
           ^
/usr/ports/net-im/toxic/work/toxic-0.7.1/src/misc_tools.c:480:22: error: use of undeclared identifier 'AF_INET'
    return inet_pton(AF_INET, address, &(s_addr.sin_addr)) != 0;
                     ^
2 errors generated.
