### PR TITLE
add missing implicit include

### DIFF
--- a/src/qr_code.c
+++ b/src/qr_code.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <qrencode.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "toxic.h"
 #include "windows.h"


### PR DESCRIPTION
In `src/qr_code.c`, both `memset` and `memcpy` are not defined (rather, implicitly defined), this PR simply include `string.h` which define it.

```
src/qr_code.c:167:5: warning: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
src/qr_code.c:167:5: warning: incompatible implicit declaration of built-in function ‘memset’
src/qr_code.c:182:21: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
src/qr_code.c:182:21: warning: incompatible implicit declaration of built-in function ‘memcpy’
```
