### PR TITLE
avoid unnecessary redrawing

### DIFF
--- a/src/friendlist.c
+++ b/src/friendlist.c
@@ -666,7 +666,7 @@ static void draw_del_popup(void)
     wattroff(PendingDelete.popup, A_BOLD);
     wprintw(PendingDelete.popup, "? y/n");
 
-    wrefresh(PendingDelete.popup);
+    wnoutrefresh(PendingDelete.popup);
 }
 
 /* deletes contact from blocked list */
@@ -895,7 +895,7 @@ static void blocklist_onDraw(ToxWindow *self, Tox *m, int y2, int x2)
             wprintw(self->window, "%02X", Blocked.list[selected_num].pub_key[i] & 0xff);
     }
 
-    wrefresh(self->window);
+    wnoutrefresh(self->window);
     draw_del_popup();
 
     if (self->help->active)
@@ -1112,7 +1112,7 @@ static void friendlist_onDraw(ToxWindow *self, Tox *m)
             wprintw(self->window, "%02X", Friends.list[selected_num].pub_key[i] & 0xff);
     }
 
-    wrefresh(self->window);
+    wnoutrefresh(self->window);
     draw_del_popup();
 
     if (self->help->active)

--- a/src/groupchat.c
+++ b/src/groupchat.c
@@ -693,7 +693,7 @@ static void groupchat_onDraw(ToxWindow *self, Tox *m)
     int new_x = ctx->start ? x2 - 1 : MAX(0, wcswidth(ctx->line, ctx->pos));
     wmove(self->window, y + 1, new_x);
 
-    wrefresh(self->window);
+    wnoutrefresh(self->window);
 
     if (self->help->active)
         help_onDraw(self);

--- a/src/help.c
+++ b/src/help.c
@@ -127,7 +127,7 @@ static void help_draw_menu(ToxWindow *self)
     wprintw(win, "it menu\n");
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 static void help_draw_bottom_menu(WINDOW *win)
@@ -211,7 +211,7 @@ static void help_draw_global(ToxWindow *self)
     help_draw_bottom_menu(win);
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 static void help_draw_chat(ToxWindow *self)
@@ -255,7 +255,7 @@ static void help_draw_chat(ToxWindow *self)
     help_draw_bottom_menu(win);
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 static void help_draw_keys(ToxWindow *self)
@@ -281,7 +281,7 @@ static void help_draw_keys(ToxWindow *self)
     help_draw_bottom_menu(win);
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 static void help_draw_group(ToxWindow *self)
@@ -299,7 +299,7 @@ static void help_draw_group(ToxWindow *self)
     help_draw_bottom_menu(win);
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 #ifdef PYTHON
@@ -318,7 +318,7 @@ static void help_draw_plugin(ToxWindow *self)
     help_draw_bottom_menu(win);
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 #endif
 
@@ -341,7 +341,7 @@ static void help_draw_contacts(ToxWindow *self)
     help_draw_bottom_menu(win);
 
     box(win, ACS_VLINE, ACS_HLINE);
-    wrefresh(win);
+    wnoutrefresh(win);
 }
 
 void help_onKey(ToxWindow *self, wint_t key)
@@ -411,8 +411,6 @@ void help_onKey(ToxWindow *self, wint_t key)
 
 void help_onDraw(ToxWindow *self)
 {
-    curs_set(0);
-
     switch (self->help->type) {
         case HELP_MENU:
             help_draw_menu(self);


### PR DESCRIPTION
Currently, the help screen redraws itself continuously, which causes annoying
flicker, and is problematic over ssh or when using monitor mode in screen.

This PR fixes this problem by changing wrefresh() in *_onDraw() to
wnoutrefresh(), so the screen isn't refreshed prematurely, and removing
curs_set(0) in help_onDraw(), which also causes unnecessary drawing if the
cursor had a different state.