### PR TITLE
Refresh devices

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -633,6 +633,9 @@ void cmd_list_devices(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*
         return;
     }
 
+    // Refresh device list.
+    get_devices_names();
+
     print_devices(self, type);
 
     return;

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -100,34 +100,7 @@ DeviceError init_devices(ToxAV *av_)
 DeviceError init_devices()
 #endif /* AUDIO */
 {
-    const char *stringed_device_list;
-
-    size[input] = 0;
-
-    if ( (stringed_device_list = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER)) ) {
-        ddevice_names[input] = alcGetString(NULL, ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER);
-
-        for ( ; *stringed_device_list && size[input] < MAX_DEVICES; ++size[input] ) {
-            devices_names[input][size[input]] = stringed_device_list;
-            stringed_device_list += strlen( stringed_device_list ) + 1;
-        }
-    }
-
-    size[output] = 0;
-
-    if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
-        stringed_device_list = alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER);
-    else
-        stringed_device_list = alcGetString(NULL, ALC_DEVICE_SPECIFIER);
-
-    if (stringed_device_list) {
-        ddevice_names[output] = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
-
-        for ( ; *stringed_device_list && size[output] < MAX_DEVICES; ++size[output] ) {
-            devices_names[output][size[output]] = stringed_device_list;
-            stringed_device_list += strlen( stringed_device_list ) + 1;
-        }
-    }
+    get_devices_names();
 
     // Start poll thread
     if (pthread_mutex_init(&mutex, NULL) != 0)
@@ -158,6 +131,38 @@ DeviceError terminate_devices()
         return (DeviceError) de_InternalError;
 
     return (DeviceError) de_None;
+}
+
+void get_devices_names() {
+
+    const char *stringed_device_list;
+
+    size[input] = 0;
+
+    if ( (stringed_device_list = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER)) ) {
+        ddevice_names[input] = alcGetString(NULL, ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER);
+
+        for ( ; *stringed_device_list && size[input] < MAX_DEVICES; ++size[input] ) {
+            devices_names[input][size[input]] = stringed_device_list;
+            stringed_device_list += strlen( stringed_device_list ) + 1;
+        }
+    }
+
+    size[output] = 0;
+
+    if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
+        stringed_device_list = alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER);
+    else
+        stringed_device_list = alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+
+    if (stringed_device_list) {
+        ddevice_names[output] = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
+
+        for ( ; *stringed_device_list && size[output] < MAX_DEVICES; ++size[output] ) {
+            devices_names[output][size[output]] = stringed_device_list;
+            stringed_device_list += strlen( stringed_device_list ) + 1;
+        }
+    }
 }
 
 DeviceError device_mute(DeviceType type, uint32_t device_idx)

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -481,8 +481,9 @@ void print_devices(ToxWindow *self, DeviceType type)
 {
     int i;
 
-    for (i = 0; i < size[type]; ++i)
-        line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%d: %s", i, devices_names[type][i]);
+    for (i = 0; i < size[type]; ++i) {
+        line_info_add(self, NULL, NULL, NULL, SYS_MSG, i == primary_device[type] ? 1 : 0, 0, "%d: %s", i, devices_names[type][i]);
+    }
 
     return;
 }

--- a/src/audio_device.h
+++ b/src/audio_device.h
@@ -61,6 +61,7 @@ DeviceError init_devices(ToxAV *av);
 DeviceError init_devices();
 #endif /* AUDIO */
 
+void get_devices_names();
 DeviceError terminate_devices();
 
 /* Callback handles ready data from INPUT device */


### PR DESCRIPTION
Keep device list up to date with devices added during runtime. Such as connecting a bluetooth headset.