### PR TITLE
Reproducible Builds: Update install.mk

### DIFF
--- a/cfg/targets/install.mk
+++ b/cfg/targets/install.mk
@@ -35,7 +35,7 @@ install: $(BUILD_DIR)/toxic
 		mv temp_file $$file ;\
 		sed -e 's:__DATADIR__:'$(abspath $(DATADIR))':g' $$file > temp_file && \
 		mv temp_file $$file ;\
-		gzip -f -9 $$file ;\
+		gzip -f -n -9 $$file ;\
 	done
 
 .PHONY: install


### PR DESCRIPTION
Making toxic reproducible by adding gzip -n flag to remove time-stamp from the toxic.1.gz toxic.conf.5.gz man pages.