### PR TITLE
Repair operating system checks

### DIFF
--- a/src/misc_tools.c
+++ b/src/misc_tools.c
@@ -26,10 +26,8 @@
 #include <time.h>
 #include <limits.h>
 #include <dirent.h>
-#if SYSTEM == BSD
 #include <netinet/in.h>
 #include <sys/socket.h>
-#endif /* BSD! */
 #include <arpa/inet.h>
 #include <sys/stat.h>
 

--- a/src/video_device.c
+++ b/src/video_device.c
@@ -69,7 +69,7 @@ typedef struct VideoDevice {
     void *cb_data;                          /* Data to be passed to callback */
     int32_t friend_number;                  /* ToxAV friend number */
 
-#if defined(__linux__) || SYSTEM == BSD
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
     int fd;                                 /* File descriptor of video device selected/opened */
     struct v4l2_format fmt;
     struct VideoBuffer *buffers;
@@ -136,7 +136,7 @@ static void yuv420tobgr(uint16_t width, uint16_t height, const uint8_t *y,
     }
 }
 
-#if defined(__linux__) || SYSTEM == BSD
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 static void yuv422to420(uint8_t *plane_y, uint8_t *plane_u, uint8_t *plane_v,
                         uint8_t *input, uint16_t width, uint16_t height)
 {
@@ -724,14 +724,14 @@ void *video_thread_poll (void *arg) // TODO: maybe use thread for every input so
                     XFlush(device->x_display);
                     free(img_data);
 
-#if defined(__linux__) || SYSTEM == BSD
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 
                     if ( -1 == xioctl(device->fd, VIDIOC_QBUF, &buf) ) {
                         unlock;
                         continue;
                     }
 
-#endif /* __linux__ / BSD */
+#endif
 
                 }
 
@@ -787,7 +787,7 @@ VideoDeviceError close_video_device(VideoDeviceType type, uint32_t device_idx)
             XCloseDisplay(device->x_display);
             pthread_mutex_destroy(device->mutex);
 
-#if defined(__linux__) || SYSTEM == BSD
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
             free(device->buffers);
 #endif /* __linux__ / BSD */
 


### PR DESCRIPTION
This is to revert the ‘SYSTEM == BSD’ breakage.
I think a check for v4l would be better.