### PR TITLE
fix compilation for newest toxcore version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 
 -include $(CFG_DIR)/global_vars.mk
 
-LIBS = toxcore ncursesw libconfig libqrencode
+LIBS = libtoxcore libtoxav ncursesw libconfig libqrencode
 
 CFLAGS = -std=gnu99 -pthread -Wall -g -fstack-protector-all
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
I'm using the latest release of toxcore (https://github.com/TokTok/c-toxcore/tree/v0.2.1) and had to make these changes to be able to compile.