### PR TITLE
Add an option to disable qr codes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
 | [LibConfig](http://www.hyperrealm.com/libconfig)     | BASE                       | libconfig-dev       |
 | [GNUmake](https://www.gnu.org/software/make)         | BASE                       | make                |
 | [libcurl](http://curl.haxx.se/)                      | BASE                       | libcurl4-openssl-dev|
-| [libqrencode](https://fukuchi.org/works/qrencode/)   | BASE                       | libqrencode-dev     |
+| [libqrencode](https://fukuchi.org/works/qrencode/)   | QRCODE                     | libqrencode-dev     |
 | [OpenAL](http://openal.org)                          | AUDIO, SOUND NOTIFICATIONS | libopenal-dev       |
 | [OpenALUT](http://openal.org)                        | SOUND NOTIFICATIONS        | libalut-dev         |
 | [LibNotify](https://developer.gnome.org/libnotify)   | DESKTOP NOTIFICATIONS      | libnotify-dev       |

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFG_DIR = $(BASE_DIR)/cfg
 
 -include $(CFG_DIR)/global_vars.mk
 
-LIBS = toxcore ncursesw libconfig libqrencode
+LIBS = toxcore ncursesw libconfig
 
 CFLAGS = -std=gnu99 -pthread -Wall -g -fstack-protector-all
 CFLAGS += '-DTOXICVER="$(VERSION)"' -DHAVE_WIDECHAR -D_XOPEN_SOURCE_EXTENDED -D_FILE_OFFSET_BITS=64

--- a/cfg/checks/check_features.mk
+++ b/cfg/checks/check_features.mk
@@ -34,6 +34,12 @@ ifneq ($(DESK_NOTIFY), disabled)
     -include $(CHECKS_DIR)/desktop_notifications.mk
 endif
 
+# Check if we want build QR export support
+QR_CODE = $(shell if [ -z "$(DISABLE_QRCODE)" ] || [ "$(DISABLE_QRCODE)" = "0" ] ; then echo enabled ; else echo disabled ; fi)
+ifneq ($(QR_CODE), disabled)
+    -include $(CHECKS_DIR)/qr.mk
+endif
+
 # Check if we want build QR exported as PNG support
 QR_PNG = $(shell if [ -z "$(DISABLE_QRPNG)" ] || [ "$(DISABLE_QRPNG)" = "0" ] ; then echo enabled ; else echo disabled ; fi)
 ifneq ($(QR_PNG), disabled)

--- a/cfg/checks/qr.mk
+++ b/cfg/checks/qr.mk
@@ -1,0 +1,15 @@
+# Variables for QR export support
+QR_LIBS = libqrencode
+QR_CFLAGS = -DQRCODE
+
+# Check if we can build QR export support
+CHECK_QR_LIBS = $(shell pkg-config --exists $(QR_LIBS) || echo -n "error")
+ifneq ($(CHECK_QR_LIBS), error)
+    LIBS += $(QR_LIBS)
+    CFLAGS += $(QR_CFLAGS)
+else ifneq ($(MAKECMDGOALS), clean)
+    MISSING_QR_LIBS = $(shell for lib in $(QR_LIBS) ; do if ! $(PKG_CONFIG) --exists $$lib ; then echo $$lib ; fi ; done)
+    $(warning WARNING -- Toxic will be compiled without QR export support)
+    $(warning WARNING -- You need these libraries for QR export support)
+    $(warning WARNING -- $(MISSING_QR_LIBS))
+endif

--- a/cfg/targets/help.mk
+++ b/cfg/targets/help.mk
@@ -14,6 +14,7 @@ help:
 	@echo "  DISABLE_AV:             Set to \"1\" to force building without audio call support"
 	@echo "  DISABLE_SOUND_NOTIFY:   Set to \"1\" to force building without sound notification support"
 	@echo "  DISABLE_DESKTOP_NOTIFY: Set to \"1\" to force building without desktop notifications support"
+	@echo "  DISABLE_QRCODE:         Set to \"1\" to force building without QR export support"
 	@echo "  DISABLE_QRPNG:          Set to \"1\" to force building without QR exported as PNG support"
 	@echo "  ENABLE_PYTHON:          Set to \"1\" to enable building with Python scripting support"
 	@echo "  USER_CFLAGS:            Add custom flags to default CFLAGS"

--- a/src/chat.c
+++ b/src/chat.c
@@ -65,15 +65,22 @@ static void init_infobox(ToxWindow *self);
 static void kill_infobox(ToxWindow *self);
 #endif  /* AUDIO */
 
-#if defined(AUDIO) && defined(PYTHON)
-#define AC_NUM_CHAT_COMMANDS 32
-#elif AUDIO
-#define AC_NUM_CHAT_COMMANDS 31
-#elif PYTHON
-#define AC_NUM_CHAT_COMMANDS 23
+#ifdef AUDIO
+#define AC_NUM_CHAT_COMMANDS_AUDIO 9
 #else
-#define AC_NUM_CHAT_COMMANDS 22
+#define AC_NUM_CHAT_COMMANDS_AUDIO 0
 #endif /* AUDIO */
+#ifdef PYTHON
+#define AC_NUM_CHAT_COMMANDS_PYTHON 1
+#else
+#define AC_NUM_CHAT_COMMANDS_PYTHON 0
+#endif /* PYTHON */
+#ifdef QRCODE
+#define AC_NUM_CHAT_COMMANDS_QRCODE 1
+#else
+#define AC_NUM_CHAT_COMMANDS_QRCODE 0
+#endif /* QRCODE */
+#define AC_NUM_CHAT_COMMANDS (21 + AC_NUM_CHAT_COMMANDS_AUDIO + AC_NUM_CHAT_COMMANDS_PYTHON + AC_NUM_CHAT_COMMANDS_QRCODE)
 
 /* Array of chat command names used for tab completion. */
 static const char chat_cmd_list[AC_NUM_CHAT_COMMANDS][MAX_CMDNAME_SIZE] = {
@@ -91,7 +98,9 @@ static const char chat_cmd_list[AC_NUM_CHAT_COMMANDS][MAX_CMDNAME_SIZE] = {
     { "/join"       },
     { "/log"        },
     { "/myid"       },
+#ifdef QRCODE
     { "/myqr"       },
+#endif /* QRCODE */
     { "/nick"       },
     { "/note"       },
     { "/nospam"     },

--- a/src/execute.c
+++ b/src/execute.c
@@ -52,7 +52,9 @@ static struct cmd_func global_commands[] = {
     { "/help",      cmd_prompt_help   },
     { "/log",       cmd_log           },
     { "/myid",      cmd_myid          },
+#ifdef QRCODE
     { "/myqr",      cmd_myqr          },
+#endif /* QRCODE */
     { "/nick",      cmd_nick          },
     { "/note",      cmd_note          },
     { "/nospam",    cmd_nospam        },

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -431,6 +431,7 @@ void cmd_myid(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
     line_info_add(self, NULL, NULL, NULL, SYS_MSG, 0, 0, "%s", id_string);
 }
 
+#ifdef QRCODE
 void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
 {
     char id_string[TOX_ADDRESS_SIZE * 2 + 1];
@@ -488,6 +489,7 @@ void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
 
 #endif /* QRPNG */
 }
+#endif /* QRCODE */
 
 void cmd_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
 {

--- a/src/global_commands.h
+++ b/src/global_commands.h
@@ -35,7 +35,9 @@ void cmd_decline(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)
 void cmd_groupchat(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_log(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_myid(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
+#ifdef QRCODE
 void cmd_myqr(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
+#endif /* QRCODE */
 void cmd_nick(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_note(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_nospam(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/groupchat.c
+++ b/src/groupchat.c
@@ -69,15 +69,17 @@ static int max_groupchat_index = 0;
 extern struct user_settings *user_settings;
 extern struct Winthread Winthread;
 
-#if defined(AUDIO) && defined(PYTHON)
-#define AC_NUM_GROUP_COMMANDS 25
-#elif AUDIO
-#define AC_NUM_GROUP_COMMANDS 24
-#elif PYTHON
-#define AC_NUM_GROUP_COMMANDS 21
+#ifdef PYTHON
+#define AC_NUM_GROUP_COMMANDS_PYTHON 1
 #else
-#define AC_NUM_GROUP_COMMANDS 20
-#endif /* AUDIO */
+#define AC_NUM_GROUP_COMMANDS_PYTHON 0
+#endif /* PYTHON */
+#ifdef QRCODE
+#define AC_NUM_GROUP_COMMANDS_QRCODE 1
+#else
+#define AC_NUM_GROUP_COMMANDS_QRCODE 0
+#endif /* QRCODE */
+#define AC_NUM_GROUP_COMMANDS (19 + AC_NUM_GROUP_COMMANDS_PYTHON + AC_NUM_GROUP_COMMANDS_QRCODE)
 
 /* Array of groupchat command names used for tab completion. */
 static const char group_cmd_list[AC_NUM_GROUP_COMMANDS][MAX_CMDNAME_SIZE] = {
@@ -93,7 +95,9 @@ static const char group_cmd_list[AC_NUM_GROUP_COMMANDS][MAX_CMDNAME_SIZE] = {
     { "/help"       },
     { "/log"        },
     { "/myid"       },
+#ifdef QRCODE
     { "/myqr"       },
+#endif /* QRCODE */
     { "/nick"       },
     { "/note"       },
     { "/nospam"     },

--- a/src/help.c
+++ b/src/help.c
@@ -173,11 +173,13 @@ static void help_draw_global(ToxWindow *self)
     wprintw(win, "  /log <on> or <off>         : Enable/disable logging\n");
     wprintw(win, "  /group <type>              : Create a group chat where type: text | audio\n");
     wprintw(win, "  /myid                      : Print your Tox ID\n");
+#ifdef QRCODE
 #ifdef QRPNG
     wprintw(win, "  /myqr <txt> or <png>       : Print your Tox ID's QR code to a file.\n");
 #else
     wprintw(win, "  /myqr                      : Print your Tox ID's QR code to a file.\n");
 #endif /* QRPNG */
+#endif /* QRCODE */
     wprintw(win, "  /clear                     : Clear window history\n");
     wprintw(win, "  /close                     : Close the current chat window\n");
     wprintw(win, "  /quit or /exit             : Exit Toxic\n");

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -49,19 +49,27 @@ extern struct Winthread Winthread;
 
 extern FriendsList Friends;
 FriendRequests FrndRequests;
-#if defined(PYTHON) && defined(VIDEO)
-#define AC_NUM_GLOB_COMMANDS 23
-#elif defined(PYTHON) && defined(AUDIO)
-#define AC_NUM_GLOB_COMMANDS 21
-#elif VIDEO
-#define AC_NUM_GLOB_COMMANDS 22
-#elif AUDIO
-#define AC_NUM_GLOB_COMMANDS 20
-#elif PYTHON
-#define AC_NUM_GLOB_COMMANDS 19
+#ifdef AUDIO
+#define AC_NUM_GLOB_COMMANDS_AUDIO 2
 #else
-#define AC_NUM_GLOB_COMMANDS 18
-#endif
+#define AC_NUM_GLOB_COMMANDS_AUDIO 0
+#endif /* AUDIO */
+#ifdef VIDEO
+#define AC_NUM_GLOB_COMMANDS_VIDEO 2
+#else
+#define AC_NUM_GLOB_COMMANDS_VIDEO 0
+#endif /* VIDEO */
+#ifdef PYTHON
+#define AC_NUM_GLOB_COMMANDS_PYTHON 1
+#else
+#define AC_NUM_GLOB_COMMANDS_PYTHON 0
+#endif /* PYTHON */
+#ifdef QRCODE
+#define AC_NUM_GLOB_COMMANDS_QRCODE 1
+#else
+#define AC_NUM_GLOB_COMMANDS_QRCODE 0
+#endif /* QRCODE */
+#define AC_NUM_GLOB_COMMANDS (17 + AC_NUM_GLOB_COMMANDS_AUDIO + AC_NUM_GLOB_COMMANDS_VIDEO + AC_NUM_GLOB_COMMANDS_PYTHON + AC_NUM_GLOB_COMMANDS_QRCODE)
 
 /* Array of global command names used for tab completion. */
 static const char glob_cmd_list[AC_NUM_GLOB_COMMANDS][MAX_CMDNAME_SIZE] = {
@@ -76,7 +84,9 @@ static const char glob_cmd_list[AC_NUM_GLOB_COMMANDS][MAX_CMDNAME_SIZE] = {
     { "/help"       },
     { "/log"        },
     { "/myid"       },
+#ifdef QRCODE
     { "/myqr"       },
+#endif /* QRCODE */
     { "/nick"       },
     { "/note"       },
     { "/nospam"     },

--- a/src/qr_code.c
+++ b/src/qr_code.c
@@ -20,6 +20,8 @@
  *
  */
 
+#ifdef QRCODE
+
 #include <stdlib.h>
 #include <qrencode.h>
 #include <stdbool.h>
@@ -208,3 +210,5 @@ int ID_to_QRcode_png(const char *tox_id, const char *outfile)
     return 0;
 }
 #endif /* QRPNG */
+
+#endif /* QRCODE */

--- a/src/qr_code.h
+++ b/src/qr_code.h
@@ -23,6 +23,8 @@
 #ifndef QR_CODE
 #define QR_CODE
 
+#ifdef QRCODE
+
 #define QRCODE_FILENAME_EXT ".QRcode"
 
 /* Converts a tox ID string into a QRcode and prints it into the given filename.
@@ -41,5 +43,7 @@ int ID_to_QRcode_txt(const char *tox_id, const char *outfile);
  */
 int ID_to_QRcode_png(const char *tox_id, const char *outfile);
 #endif /* QRPNG */
+
+#endif /* QRCODE */
 
 #endif /* QR_CODE */


### PR DESCRIPTION
This PR makes libqrencode optional.

Note: I have not removed the libqrencode flag in the OSX makefile (https://github.com/JFreegman/toxic/blob/master/cfg/systems/Darwin.mk#L9), because I cannot test on that platform and I do not want to break things. However I believe it can be removed, because pkg-config should also be called on OSX and add the flag. I can amend the commit to remove the flag if needed, please let me know.