### PR TITLE
Add config option for the notification timeout duration

### DIFF
--- a/doc/toxic.conf.5
+++ b/doc/toxic.conf.5
@@ -133,6 +133,11 @@ How often in seconds to auto\-save the Tox data file\&. (integer; 0 to disable)
 Maximum lines for chat window history\&. Integer value\&. (for example: 700)
 .RE
 .PP
+\fBnotification_timeout\fR
+.RS 4
+Time in milliseconds to display a notification\&. (for example: 3000)
+.RE
+.PP
 \fBline_join\fR
 .RS 4
 Indicator for when someone connects or joins a group\&. Three characters max for line_ settings\&.

--- a/doc/toxic.conf.5.asc
+++ b/doc/toxic.conf.5.asc
@@ -84,6 +84,9 @@ OPTIONS
     *history_size*;;
         Maximum lines for chat window history. Integer value. (for example: 700)
 
+    *notification_timeout*;;
+        Time in milliseconds to display a notification. Integer value. (for example: 3000)
+
     *line_join*;;
         Indicator for when someone connects or joins a group.
         Three characters max for line_ settings.

--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -53,6 +53,9 @@ ui = {
   // maximum lines for chat window history
   history_size=700;
 
+  // time in milliseconds to display a notification
+  notification_timeout=3000;
+
   // Indicator for display when someone connects or joins a group.
   line_join="-->";
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -58,6 +58,7 @@ static struct ui_strings {
     const char *native_colors;
     const char *autolog;
     const char *history_size;
+    const char *notification_timeout;
     const char *show_typing_self;
     const char *show_typing_other;
     const char *show_welcome_msg;
@@ -86,6 +87,7 @@ static struct ui_strings {
     "native_colors",
     "autolog",
     "history_size",
+    "notification_timeout",
     "show_typing_self",
     "show_typing_other",
     "show_welcome_msg",
@@ -114,6 +116,7 @@ static void ui_defaults(struct user_settings *settings)
     settings->bell_on_invite = 0;
     settings->colour_theme = DFLT_COLS;
     settings->history_size = 700;
+    settings->notification_timeout = 3000;
     settings->show_typing_self = SHOW_TYPING_ON;
     settings->show_typing_other = SHOW_TYPING_ON;
     settings->show_welcome_msg = SHOW_WELCOME_MSG_ON;
@@ -372,6 +375,7 @@ int settings_load(struct user_settings *s, const char *patharg)
         config_setting_lookup_bool(setting, ui_strings.show_connection_msg, &s->show_connection_msg);
 
         config_setting_lookup_int(setting, ui_strings.history_size, &s->history_size);
+        config_setting_lookup_int(setting, ui_strings.notification_timeout, &s->notification_timeout);
         config_setting_lookup_int(setting, ui_strings.nodeslist_update_freq, &s->nodeslist_update_freq);
         config_setting_lookup_int(setting, ui_strings.autosave_freq, &s->autosave_freq);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -49,6 +49,7 @@ struct user_settings {
 
     int colour_theme;      /* boolean (0 for default toxic colours) */
     int history_size;      /* int between MIN_HISTORY and MAX_HISTORY */
+    int notification_timeout;
     int show_typing_self;  /* boolean */
     int show_typing_other; /* boolean */
     int show_welcome_msg;  /* boolean */

--- a/src/toxic.c
+++ b/src/toxic.c
@@ -1332,7 +1332,7 @@ int main(int argc, char **argv)
 
 #endif /* PYTHON */
 
-    init_notify(60, 3000);
+    init_notify(60, user_settings->notification_timeout);
 
     /* screen/tmux auto-away timer */
     if (init_mplex_away_timer(m) == -1) {


### PR DESCRIPTION
The default of 3000 milliseconds seems like a comfortable default for the notification timeout, but it seems quite sensible to allow this value to be controlled by the user. If the change is inadequate please provide feedback so that I may complete other required changes. I put this together based on how the hard-coded 3000 was being used and how other config options are programmed.