### PR TITLE
Fix non-working bell notifications (issue #459)

### DIFF
--- a/src/xtra.c
+++ b/src/xtra.c
@@ -302,7 +302,7 @@ static long unsigned int focused_window_id(void)
 
 int is_focused(void)
 {
-    return Xtra.proxy_window == focused_window_id() || Xtra.terminal_window == focused_window_id();
+    return Xtra.display && (Xtra.proxy_window == focused_window_id() || Xtra.terminal_window == focused_window_id());
 }
 
 int init_xtra(drop_callback d)


### PR DESCRIPTION
The problem with the bell notifications only happens when Toxic is compiled with X11 support, but does not run under X. This commit changes Toxic's behavior such that it behaves identically when not running under an X session, no matter if it has been compiled with X11 support or not.