### PR TITLE
Fix problem with Clang build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,6 +13,7 @@
 | [Tox Core](https://github.com/toktok/c-toxcore)      | BASE                       | *None*              |
 | [NCurses](https://www.gnu.org/software/ncurses)      | BASE                       | libncursesw5-dev    |
 | [LibConfig](http://www.hyperrealm.com/libconfig)     | BASE                       | libconfig-dev       |
+| [Linux Headers](https://www.kernel.org)              | BASE                       | linux-headers-*     |
 | [GNUmake](https://www.gnu.org/software/make)         | BASE                       | make                |
 | [libcurl](http://curl.haxx.se/)                      | BASE                       | libcurl4-openssl-dev|
 | [libqrencode](https://fukuchi.org/works/qrencode/)   | QRCODE                     | libqrencode-dev     |

--- a/src/autocomplete.c
+++ b/src/autocomplete.c
@@ -25,10 +25,14 @@
 #include <string.h>
 
 #ifdef __APPLE__
-#include <sys/types.h>
 #include <sys/dir.h>
+#include <sys/sysinfo.h>
+#include <sys/types.h>
 #else
 #include <dirent.h>
+#ifdef __linux
+#include <linux/limits.h>//This includes NAME_MAX and PATH_MAX
+#endif /* __linux__ */
 #endif /* __APPLE__ */
 
 #include "configdir.h"

--- a/src/file_transfers.h
+++ b/src/file_transfers.h
@@ -25,6 +25,15 @@
 
 #include <limits.h>
 
+//This includes NAME_MAX and PATH_MAX
+#ifdef __APPLE__
+#include <sys/sysinfo.h>
+#elif __linux__
+#include <linux/limits.h>
+#else
+#include <limits.h>//hope that this is correct for other systems.
+#endif
+
 #include "notify.h"
 #include "toxic.h"
 #include "windows.h"

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,7 +22,12 @@
 
 #ifndef SETTINGS_H
 #define SETTINGS_H
-
+//Include NAME_MAX and PATH_MAX
+#ifdef __APPLE__
+#include <sys/sysinfo.h>
+#elif __linux__
+#include <linux/limits.h>
+#endif
 #include <limits.h>
 
 #include <tox/tox.h>


### PR DESCRIPTION
Fix inclusion of NAME_MAX and PATH_MAX macros.
On Linux they are defined at <linux/limits.h>
On Apple they may be defined at <sys/sysinfo.h>, if
possible please check the apple definitions.

Signed-off-by: Josiah Mullins <JoMull01@protonmail.com>