### PR TITLE
game_chess.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/game_chess.c
+++ b/src/game_chess.c
@@ -1626,11 +1626,11 @@ static void chess_print_status(WINDOW *win, ChessState *state)
     }
 
     int x_mid = (board->x_left_bound + (CHESS_TILE_SIZE_X * (CHESS_BOARD_COLUMNS / 2))) - (strlen(message) / 2);
-    mvwprintw(win, board->y_top_bound  - 2, x_mid, message);
+    mvwprintw(win, board->y_top_bound  - 2, x_mid, "%s", message);
 
     if (state->message_length > 0) {
         x_mid = (board->x_left_bound + (CHESS_TILE_SIZE_X * (CHESS_BOARD_COLUMNS / 2))) - (state->message_length / 2);
-        mvwprintw(win, board->y_bottom_bound + 2, x_mid, state->status_message);
+        mvwprintw(win, board->y_bottom_bound + 2, x_mid, "%s", state->status_message);
     }
 
     wattroff(win, A_BOLD);


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    toxic/src/game_chess.c:1633:63: error:
      format not a string literal and no format arguments [-Werror=format-security]
     1633 |         mvwprintw(win, board->y_bottom_bound + 2, x_mid, state->status_message);
          |                                                          ~~~~~^~~~~~~~~~~~~~~~

Let's wrap all the missing places with "%s" format.