### PR TITLE
Make sure conference audio calls are properly flagged

### DIFF
--- a/src/conference.c
+++ b/src/conference.c
@@ -1334,7 +1334,7 @@ bool toggle_conference_push_to_talk(uint32_t conferencenum, bool enabled)
     return true;
 }
 
-bool enable_conference_audio(Tox *tox, uint32_t conferencenum)
+bool enable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum)
 {
     if (!toxav_groupchat_av_enabled(tox, conferencenum)) {
         if (toxav_groupchat_enable_av(tox, conferencenum, audio_conference_callback, NULL) != 0) {
@@ -1342,10 +1342,16 @@ bool enable_conference_audio(Tox *tox, uint32_t conferencenum)
         }
     }
 
-    return init_conference_audio_input(tox, conferencenum);
+    bool success = init_conference_audio_input(tox, conferencenum);
+
+    if (success) {
+        self->is_call = true;
+    }
+
+    return success;
 }
 
-bool disable_conference_audio(Tox *tox, uint32_t conferencenum)
+bool disable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum)
 {
     ConferenceChat *chat = &conferences[conferencenum];
 
@@ -1358,7 +1364,13 @@ bool disable_conference_audio(Tox *tox, uint32_t conferencenum)
         chat->audio_enabled = false;
     }
 
-    return toxav_groupchat_disable_av(tox, conferencenum) == 0;
+    bool success = toxav_groupchat_disable_av(tox, conferencenum) == 0;
+
+    if (success) {
+        self->is_call = false;
+    }
+
+    return success;
 }
 
 bool conference_mute_self(uint32_t conferencenum)

--- a/src/conference.h
+++ b/src/conference.h
@@ -103,8 +103,8 @@ uint32_t get_name_list_entries_by_prefix(uint32_t conferencenum, const char *pre
         uint32_t maxpeers);
 
 bool init_conference_audio_input(Tox *tox, uint32_t conferencenum);
-bool enable_conference_audio(Tox *tox, uint32_t conferencenum);
-bool disable_conference_audio(Tox *tox, uint32_t conferencenum);
+bool enable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum);
+bool disable_conference_audio(ToxWindow *self, Tox *tox, uint32_t conferencenum);
 bool toggle_conference_push_to_talk(uint32_t conferencenum, bool enabled);
 void audio_conference_callback(void *tox, uint32_t conferencenum, uint32_t peernum,
                                const int16_t *pcm, unsigned int samples, uint8_t channels, uint32_t

--- a/src/conference_commands.c
+++ b/src/conference_commands.c
@@ -108,7 +108,7 @@ void cmd_enable_audio(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*
         return;
     }
 
-    if (enable ? enable_conference_audio(m, self->num) : disable_conference_audio(m, self->num)) {
+    if (enable ? enable_conference_audio(self, m, self->num) : disable_conference_audio(self, m, self->num)) {
         print_err(self, enable ? "Enabled conference audio. Use the '/ptt' command to toggle Push-To-Talk."
                   : "Disabled conference audio");
     } else {


### PR DESCRIPTION
This fixes a bug causing the conference audio noise animations and indicators from properly displaying