### PR TITLE
Reduce sound notify polling by factor of 10

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -318,7 +318,7 @@ void *do_playing(void *_p)
         has_looping = false;
 
         control_unlock();
-        sleep_thread(10000L);
+        sleep_thread(100000L);
     }
 
     pthread_exit(NULL);

--- a/src/windows.c
+++ b/src/windows.c
@@ -808,15 +808,13 @@ void draw_active_window(Tox *m)
         a->onDraw(a, m);
         wrefresh(a->window);
     }
-
 #ifdef AUDIO
     else if (a->is_call && timed_out(a->chatwin->infobox.lastupdate, 1)) {
         touchwin(a->window);
         a->onDraw(a, m);
         wrefresh(a->window);
     }
-
-#endif
+#endif  // AUDIO
 
 #ifdef GAMES
 


### PR DESCRIPTION
Polling 100 times per second is excessive. This should help reduce Toxic's resource usage without a noticable difference to the user.