### PR TITLE
Fix issue with audio VAD threshold

### DIFF
--- a/src/audio_call.c
+++ b/src/audio_call.c
@@ -204,7 +204,7 @@ static int start_transmission(ToxWindow *self, Call *call)
         return -1;
     }
 
-    DeviceError error = open_input_device(&call->in_idx, read_device_callback, &self->num, false,
+    DeviceError error = open_input_device(&call->in_idx, read_device_callback, &self->num,
                                           CallControl.audio_sample_rate, CallControl.audio_frame_duration, CallControl.audio_channels);
 
     if (error != de_None) {

--- a/src/audio_device.c
+++ b/src/audio_device.c
@@ -484,8 +484,7 @@ DeviceError set_al_device(DeviceType type, int32_t selection)
     return de_None;
 }
 
-static DeviceError open_device(DeviceType type, uint32_t *device_idx,
-                               DataHandleCallback cb, void *cb_data, bool enable_VAD,
+static DeviceError open_device(DeviceType type, uint32_t *device_idx, DataHandleCallback cb, void *cb_data,
                                uint32_t sample_rate, uint32_t frame_duration, uint8_t channels)
 {
     if (channels != 1 && channels != 2) {
@@ -530,7 +529,11 @@ static DeviceError open_device(DeviceType type, uint32_t *device_idx,
         device->cb = cb;
         device->cb_data = cb_data;
 #ifdef AUDIO
-        device->VAD_threshold = enable_VAD ? user_settings->VAD_threshold : 0.0f;
+
+        if (user_settings->VAD_threshold >= 0.0f) {
+            device->VAD_threshold = user_settings->VAD_threshold;
+        }
+
 #else
         device->VAD_threshold = 0.0f;
 #endif
@@ -547,21 +550,15 @@ static DeviceError open_device(DeviceType type, uint32_t *device_idx,
     return de_None;
 }
 
-DeviceError open_input_device(uint32_t *device_idx,
-                              DataHandleCallback cb, void *cb_data, bool enable_VAD,
-                              uint32_t sample_rate, uint32_t frame_duration, uint8_t channels)
+DeviceError open_input_device(uint32_t *device_idx, DataHandleCallback cb, void *cb_data, uint32_t sample_rate,
+                              uint32_t frame_duration, uint8_t channels)
 {
-    return open_device(input, device_idx,
-                       cb, cb_data, enable_VAD,
-                       sample_rate, frame_duration, channels);
+    return open_device(input, device_idx, cb, cb_data, sample_rate, frame_duration, channels);
 }
 
-DeviceError open_output_device(uint32_t *device_idx,
-                               uint32_t sample_rate, uint32_t frame_duration, uint8_t channels)
+DeviceError open_output_device(uint32_t *device_idx, uint32_t sample_rate, uint32_t frame_duration, uint8_t channels)
 {
-    return open_device(output, device_idx,
-                       0, 0, 0,
-                       sample_rate, frame_duration, channels);
+    return open_device(output, device_idx, 0, 0, sample_rate, frame_duration, channels);
 }
 
 DeviceError close_device(DeviceType type, uint32_t device_idx)

--- a/src/audio_device.h
+++ b/src/audio_device.h
@@ -75,11 +75,9 @@ DeviceError set_source_position(uint32_t device_idx, float x, float y, float z);
 DeviceError set_al_device(DeviceType type, int32_t selection);
 
 /* Start device */
-DeviceError open_input_device(uint32_t *device_idx,
-                              DataHandleCallback cb, void *cb_data, bool enable_VAD,
+DeviceError open_input_device(uint32_t *device_idx, DataHandleCallback cb, void *cb_data,
                               uint32_t sample_rate, uint32_t frame_duration, uint8_t channels);
-DeviceError open_output_device(uint32_t *device_idx,
-                               uint32_t sample_rate, uint32_t frame_duration, uint8_t channels);
+DeviceError open_output_device(uint32_t *device_idx, uint32_t sample_rate, uint32_t frame_duration, uint8_t channels);
 
 /* Stop device */
 DeviceError close_device(DeviceType type, uint32_t device_idx);

--- a/src/chat.c
+++ b/src/chat.c
@@ -1034,7 +1034,7 @@ static void init_infobox(ToxWindow *self)
 
     ctx->infobox.win = newwin(INFOBOX_HEIGHT, INFOBOX_WIDTH + 1, 1, x2 - INFOBOX_WIDTH);
     ctx->infobox.starttime = get_unix_time();
-    ctx->infobox.vad_lvl = 0.0f;
+    ctx->infobox.vad_lvl = user_settings->VAD_threshold;
     ctx->infobox.active = true;
     strcpy(ctx->infobox.timestr, "00");
 }

--- a/src/conference.c
+++ b/src/conference.c
@@ -1312,7 +1312,7 @@ bool init_conference_audio_input(Tox *tox, uint32_t conferencenum)
     int channels = user_settings->conference_audio_channels;
 
     bool success = (open_input_device(&chat->audio_in_idx,
-                                      conference_read_device_callback, &chat->audio_input_callback_data, true,
+                                      conference_read_device_callback, &chat->audio_input_callback_data,
                                       CONFAV_SAMPLE_RATE, CONFAV_FRAME_DURATION, channels)
                     == de_None);
 


### PR DESCRIPTION
The default VAD was always being set to 0. We now use the value provided by the config file if defined.