### PR TITLE
Add new option in config to hide peer connection messages in groups

### DIFF
--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -56,6 +56,9 @@ ui = {
   // true to show friend connection change messages on the home screen
   show_connection_msg=true;
 
+  // true to show peer connection change messages in groups (setting to false does not include user quit messages)
+  show_group_connection_msg=true;
+
   // How often in days to update the DHT nodes list. (0 to disable updates)
   nodeslist_update_freq=7;
 

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -991,7 +991,7 @@ static void groupchat_onGroupPeerJoin(ToxWindow *self, Tox *m, uint32_t groupnum
             ++chat->max_idx;
         }
 
-        if (timed_out(chat->time_connected, 60)) {   /* ignore join messages when we first connect to the group */
+        if (timed_out(chat->time_connected, 60) && user_settings->show_group_connection_msg == SHOW_GROUP_CONNECTION_MSG_ON) {   /* ignore join messages when we first connect to the group */
             line_info_add(self, true, peer->name, NULL, CONNECTION, 0, GREEN, "has joined the room");
 
             write_to_log("has joined the room", peer->name, self->chatwin->log, true);
@@ -1027,7 +1027,7 @@ void groupchat_onGroupPeerExit(ToxWindow *self, Tox *m, uint32_t groupnumber, ui
         if (length > 0) {
             line_info_add(self, true, name, NULL, DISCONNECTION, 0, RED, "[Quit]: %s", part_message);
             snprintf(log_str, sizeof(log_str), "has left the room (%s)", part_message);
-        } else {
+        } else if (user_settings->show_group_connection_msg == SHOW_GROUP_CONNECTION_MSG_ON) {
             const char *exit_string = get_group_exit_string(exit_type);
             line_info_add(self, true, name, NULL, DISCONNECTION, 0, RED, "[%s]", exit_string);
             snprintf(log_str, sizeof(log_str), "[%s]", exit_string);

--- a/src/settings.c
+++ b/src/settings.c
@@ -63,6 +63,7 @@ static struct ui_strings {
     const char *show_typing_other;
     const char *show_welcome_msg;
     const char *show_connection_msg;
+    const char *show_group_connection_msg;
     const char *nodeslist_update_freq;
     const char *autosave_freq;
 
@@ -99,6 +100,7 @@ static struct ui_strings {
     "show_typing_other",
     "show_welcome_msg",
     "show_connection_msg",
+    "show_group_connection_msg",
     "nodeslist_update_freq",
     "autosave_freq",
     "line_join",
@@ -136,6 +138,7 @@ static void ui_defaults(struct user_settings *settings)
     settings->show_typing_other = SHOW_TYPING_ON;
     settings->show_welcome_msg = SHOW_WELCOME_MSG_ON;
     settings->show_connection_msg = SHOW_CONNECTION_MSG_ON;
+    settings->show_group_connection_msg = SHOW_GROUP_CONNECTION_MSG_ON;
     settings->nodeslist_update_freq = 1;
     settings->autosave_freq = 600;
 
@@ -405,6 +408,7 @@ int settings_load(struct user_settings *s, const char *patharg)
         config_setting_lookup_bool(setting, ui_strings.show_typing_other, &s->show_typing_other);
         config_setting_lookup_bool(setting, ui_strings.show_welcome_msg, &s->show_welcome_msg);
         config_setting_lookup_bool(setting, ui_strings.show_connection_msg, &s->show_connection_msg);
+        config_setting_lookup_bool(setting, ui_strings.show_group_connection_msg, &s->show_group_connection_msg);
 
         config_setting_lookup_int(setting, ui_strings.history_size, &s->history_size);
         config_setting_lookup_int(setting, ui_strings.notification_timeout, &s->notification_timeout);

--- a/src/settings.h
+++ b/src/settings.h
@@ -54,6 +54,7 @@ struct user_settings {
     int show_typing_other; /* boolean */
     int show_welcome_msg;  /* boolean */
     int show_connection_msg;  /* boolean */
+    int show_group_connection_msg;  /* boolean */
     int nodeslist_update_freq;  /* int (<= 0 to disable updates) */
     int autosave_freq; /* int (<= 0 to disable autosave) */
 
@@ -121,6 +122,9 @@ enum settings_values {
 
     SHOW_CONNECTION_MSG_OFF = 0,
     SHOW_CONNECTION_MSG_ON = 1,
+
+    SHOW_GROUP_CONNECTION_MSG_OFF = 0,
+    SHOW_GROUP_CONNECTION_MSG_ON = 1,
 
     DFLT_HST_SIZE = 700,
 


### PR DESCRIPTION
Add new option in the config so that messages for user connections do not get added to the chat (and log). Only user quit messages will be shown.