### PR TITLE
Fix chatlog saving empty peer exit message with new config option

### DIFF
--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -1033,7 +1033,10 @@ void groupchat_onGroupPeerExit(ToxWindow *self, Tox *m, uint32_t groupnumber, ui
             snprintf(log_str, sizeof(log_str), "[%s]", exit_string);
         }
 
-        write_to_log(log_str, name, self->chatwin->log, true);
+        if (user_settings->show_group_connection_msg == SHOW_GROUP_CONNECTION_MSG_ON) {
+            write_to_log(log_str, name, self->chatwin->log, true);
+        }
+        
         sound_notify(self, silent, NT_WNDALERT_2, NULL);
     }
 


### PR DESCRIPTION
I missed the part of the chat log saving where the reason a peer exited would be saved as random data. This fixes the issue.