### PR TITLE
feat: detach group names from global name

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -130,6 +130,7 @@ static struct cmd_func groupchat_commands[] = {
     { "/list",      cmd_list           },
     { "/locktopic", cmd_set_topic_lock },
     { "/mod",       cmd_mod            },
+    { "/nick",      cmd_group_nick     },
     { "/passwd",    cmd_set_passwd     },
     { "/peerlimit", cmd_set_peerlimit  },
     { "/privacy",   cmd_set_privacy    },

--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -777,7 +777,6 @@ void cmd_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MA
 
     tox_self_set_name(m, (uint8_t *) nick, len, NULL);
     prompt_update_nick(prompt, nick);
-    set_nick_all_groups(m, nick, len);
 
     store_data(m, DATA_FILE);
 }

--- a/src/groupchat_commands.c
+++ b/src/groupchat_commands.c
@@ -76,6 +76,32 @@ void cmd_disconnect(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*ar
     }
 }
 
+void cmd_group_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
+{
+    UNUSED_VAR(window);
+
+    if (argc < 1) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Input required.");
+        return;
+    }
+
+    char nick[MAX_STR_SIZE];
+    snprintf(nick, sizeof(nick), "%s", argv[1]);
+    size_t len = strlen(nick);
+
+    if (!valid_nick(nick)) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid name.");
+        return;
+    }
+
+    len = MIN(len, TOXIC_MAX_NAME_LENGTH - 1);
+    nick[len] = '\0';
+
+    set_nick_this_group(self, m, nick, len);
+
+    store_data(m, DATA_FILE);
+}
+
 void cmd_ignore(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE])
 {
     if (argc < 1) {

--- a/src/groupchat_commands.h
+++ b/src/groupchat_commands.h
@@ -28,6 +28,7 @@
 
 void cmd_chatid(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_disconnect(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_group_nick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_ignore(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_kick(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_list(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX_STR_SIZE]);

--- a/src/groupchats.h
+++ b/src/groupchats.h
@@ -68,7 +68,7 @@ typedef struct {
 
 void exit_groupchat(ToxWindow *self, Tox *m, uint32_t groupnumber, const char *partmessage, size_t length);
 int init_groupchat_win(Tox *m, uint32_t groupnumber, const char *groupname, size_t length, Group_Join_Type join_type);
-void set_nick_all_groups(Tox *m, const char *new_nick, size_t length);
+void set_nick_this_group(ToxWindow *self, Tox *m, const char *new_nick, size_t length);
 void set_status_all_groups(Tox *m, uint8_t status);
 int get_peer_index(uint32_t groupnumber, uint32_t peer_id);
 void groupchat_onGroupPeerExit(ToxWindow *self, Tox *m, uint32_t groupnumber, uint32_t peer_id,

--- a/src/help.c
+++ b/src/help.c
@@ -183,7 +183,7 @@ static void help_draw_global(ToxWindow *self)
     wprintw(win, "  /requests                  : List pending friend requests\n");
     wprintw(win, "  /status <type>             : Set status (Online, Busy, Away)\n");
     wprintw(win, "  /note <msg>                : Set a personal note\n");
-    wprintw(win, "  /nick <nick>               : Set your nickname\n");
+    wprintw(win, "  /nick <name>               : Set your global name (doesn't affect groups)\n");
     wprintw(win, "  /nospam <value>            : Change part of your Tox ID to stop spam\n");
     wprintw(win, "  /log <on> or <off>         : Enable/disable logging\n");
     wprintw(win, "  /myid                      : Print your Tox ID\n");
@@ -307,6 +307,7 @@ static void help_draw_groupchats(ToxWindow *self)
     wprintw(win, "  /list                     : Print a list of peers currently in the group\n");
     wprintw(win, "  /locktopic                : Set the topic lock: on | off\n");
     wprintw(win, "  /mod <name>               : Promote a peer to moderator\n");
+    wprintw(win, "  /nick <name>              : Set your name for this group only\n");
     wprintw(win, "  /passwd <s>               : Set a password needed to join the group\n");
     wprintw(win, "  /peerlimit <n>            : Set the maximum number of peers that can join\n");
     wprintw(win, "  /privacy <state>          : Set the privacy state: private | public\n");
@@ -496,7 +497,7 @@ void help_onKey(ToxWindow *self, wint_t key)
             break;
 
         case L'r':
-            help_init_window(self, 26, 80);
+            help_init_window(self, 27, 80);
             self->help->type = HELP_GROUP;
             break;
     }


### PR DESCRIPTION
Group names are now set on a per-group basis and are not affected by the global /nick command.