### PR TITLE
Fix ID lookup error messages

### DIFF
--- a/src/global_commands.c
+++ b/src/global_commands.c
@@ -173,10 +173,16 @@ void cmd_add(WINDOW *window, ToxWindow *self, Tox *m, int argc, char (*argv)[MAX
 
     char id_bin[TOX_ADDRESS_SIZE] = {0};
 
-    const bool is_tox_id = (char_find(0, id, '@') == arg_length) && (arg_length >= TOX_ADDRESS_SIZE * 2);
+    const bool is_domain = char_find(0, id, '@') != arg_length;
+    const bool valid_id_size = arg_length >= TOX_ADDRESS_SIZE * 2;  // arg_length may include invite message
 
-    if (!is_tox_id) {
-        name_lookup(self, m, id_bin, id, msg);
+    if (is_domain) {
+        if (!name_lookup(self, m, id_bin, id, msg)) {
+            return;
+        }
+    } else if (!valid_id_size) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Invalid Tox ID.");
+        return;
     }
 
     char xx[3];

--- a/src/name_lookup.h
+++ b/src/name_lookup.h
@@ -23,14 +23,19 @@
 #ifndef NAME_LOOKUP
 #define NAME_LOOKUP
 
-/* Initializes http based name lookups. Note: This function must be called only once before additional
- * threads are spawned.
+/* Initializes http based name lookups.
+ *
+ * Note: This function must be called only once before additional threads are spawned.
  *
  * Returns 0 on success.
  * Returns -1 on failure.
  */
 int name_lookup_init(int curl_init_status);
 
-int name_lookup(ToxWindow *self, Tox *m, const char *id_bin, const char *addr, const char *message);
+/* Attempts to do a tox name lookup.
+ *
+ * Returns true on success.
+ */
+bool name_lookup(ToxWindow *self, Tox *m, const char *id_bin, const char *addr, const char *message);
 
 #endif /* NAME_LOOKUP */


### PR DESCRIPTION
We now properly distinguish between ID lookups and domain name lookups and print the appropriate error message for each given case