### PR TITLE
Remove invalid groupchat commands

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -142,10 +142,6 @@ static struct cmd_func groupchat_commands[] = {
     { "/unsilence", cmd_unsilence      },
     { "/voice",     cmd_set_voice      },
     { "/whois",     cmd_whois          },
-#ifdef AUDIO
-    { "/mute",      cmd_mute           },
-    { "/sense",     cmd_sense          },
-#endif /* AUDIO */
     { NULL,         NULL               },
 };
 

--- a/src/groupchats.c
+++ b/src/groupchats.c
@@ -117,12 +117,6 @@ static const char *group_cmd_list[] = {
     "/voice",
     "/whisper",
     "/whois",
-#ifdef AUDIO
-    "/lsdev",
-    "/sdev",
-    "/mute",
-    "/sense",
-#endif /* AUDIO */
 };
 
 GroupChat groupchats[MAX_GROUPCHAT_NUM];


### PR DESCRIPTION
These commands only work in audio conferences