### PR TITLE
`/fopen` command to auto-open downloaded files

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -90,9 +90,10 @@ static const char *chat_cmd_list[] = {
 #ifdef QRCODE
     "/myqr",
 #endif /* QRCODE */
+    "/fopen",
     "/nick",
-    "/note",
     "/nospam",
+    "/note",
     "/quit",
     "/savefile",
     "/sendfile",

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -406,6 +406,7 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     // make and call xdg command
     char command[MAX_STR_SIZE];
     snprintf(command, sizeof(command), "xdg-open %s", ft->file_path);
+    line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "I am about to run the xdg command.");
 
     int open_result = system(command);
 

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -335,6 +335,23 @@ void cmd_game_join(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*a
 
 #endif // GAMES
 
+void open_with_xdg(const char *filename)
+{
+    // Make the command
+    char command[MAX_STR_SIZE];
+    snprintf(command, sizeof(command), "xdg-open %s", filename);
+
+    // Call the command
+    int result = system(command);
+
+    // Did it work?
+    if (result == -1) {
+        perror("Cannot open file.\n");
+    } else {
+        printf("File opened.\n");
+    }
+}
+
 void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])
 {
     UNUSED_VAR(window);
@@ -376,7 +393,7 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
         goto on_recv_error;
     }
 
-    xdg_open(ft);
+    open_with_xdg(ft);
 
     line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Saving file [%ld] as: '%s'", idx, ft->file_path);
 

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -379,7 +379,7 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     }
 
     // make tmp_dir if it does not exist
-    /// don't need this for now
+    /// don't need this for now, prob should go somewhere else anyway.
     const char *tmp_dir = "/tmp/toxic-download-dir/";
     DIR* dir = opendir("/tmp/toxic-download-dir/");
     if (dir) {
@@ -391,16 +391,6 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     }
     // end make tmpdir if it does not exist
 
-    // make and call xdg command
-    char command[MAX_STR_SIZE];
-    snprintf(command, sizeof(command), "xdg-open %s", ft->file_path);
-
-    int open_result = system(command);
-
-    if (open_result == -1) {
-        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Could not open file.");
-    }
-    // end make and call xdg command
 
     line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Saving file [%ld] as: '%s'", idx, ft->file_path);
 
@@ -412,6 +402,17 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "%s", progline);
     ft->line_id = self->chatwin->hst->line_end->id + line_skip;
     ft->state = FILE_TRANSFER_STARTED;
+
+    // make and call xdg command
+    char command[MAX_STR_SIZE];
+    snprintf(command, sizeof(command), "xdg-open %s", ft->file_path);
+
+    int open_result = system(command);
+
+    if (open_result == -1) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Could not open file.");
+    }
+    // end make and call xdg command
 
     return;
 

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -20,6 +20,7 @@
  *
  */
 
+#include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -335,22 +336,6 @@ void cmd_game_join(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*a
 
 #endif // GAMES
 
-void open_with_xdg(const char *filename)
-{
-    // Make the command
-    char command[MAX_STR_SIZE];
-    snprintf(command, sizeof(command), "xdg-open %s", filename);
-
-    // Call the command
-    int result = system(command);
-
-    // Did it work?
-    if (result == -1) {
-        perror("Cannot open file.\n");
-    } else {
-        printf("File opened.\n");
-    }
-}
 
 void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE])
 {
@@ -393,7 +378,29 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
         goto on_recv_error;
     }
 
-    open_with_xdg(ft);
+    // make tmp_dir if it does not exist
+    /// don't need this for now
+    const char *tmp_dir = "/tmp/toxic-download-dir/";
+    DIR* dir = opendir("/tmp/toxic-download-dir/");
+    if (dir) {
+        closedir(dir);
+    }
+
+    if (mkdir(tmp_dir, S_IRWXU) == -1) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Could not create tox download /tmp/ directory.");
+    }
+    // end make tmpdir if it does not exist
+
+    // make and call xdg command
+    char command[MAX_STR_SIZE];
+    snprintf(command, sizeof(command), "xdg-open %s", ft->file_path);
+
+    int open_result = system(command);
+
+    if (open_result == -1) {
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Could not open file.");
+    }
+    // end make and call xdg command
 
     line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Saving file [%ld] as: '%s'", idx, ft->file_path);
 

--- a/src/chat_commands.c
+++ b/src/chat_commands.c
@@ -387,7 +387,7 @@ void cmd_fopen(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)
     }
 
     if (mkdir(tmp_dir, S_IRWXU) == -1) {
-        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Could not create tox download /tmp/ directory.");
+        line_info_add(self, false, NULL, NULL, SYS_MSG, 0, 0, "Could not create tox download /tmp/ directory.\n", err);
     }
     // end make tmpdir if it does not exist
 

--- a/src/chat_commands.h
+++ b/src/chat_commands.h
@@ -30,9 +30,10 @@ void cmd_autoaccept_files(WINDOW *window, ToxWindow *self, Tox *tox, int argc, c
 void cmd_cancelfile(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference_invite(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_conference_join(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_fopen(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
+void cmd_game_join(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_group_accept(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_group_invite(WINDOW *window, ToxWindow *self, Tox *tox, int argc, char (*argv)[MAX_STR_SIZE]);
-void cmd_game_join(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_savefile(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 void cmd_sendfile(WINDOW *, ToxWindow *, Tox *, int argc, char (*argv)[MAX_STR_SIZE]);
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -91,8 +91,8 @@ static struct cmd_func chat_commands[] = {
 #ifdef GAMES
     { "/play",      cmd_game_join         },
 #endif
-    { "/savefile",  cmd_savefile          },
     { "/fopen",     cmd_fopen             },
+    { "/savefile",  cmd_savefile          },
     { "/sendfile",  cmd_sendfile          },
 #ifdef AUDIO
     { "/call",      cmd_call              },

--- a/src/execute.c
+++ b/src/execute.c
@@ -92,6 +92,7 @@ static struct cmd_func chat_commands[] = {
     { "/play",      cmd_game_join         },
 #endif
     { "/savefile",  cmd_savefile          },
+    { "/fopen",     cmd_fopen             },
     { "/sendfile",  cmd_sendfile          },
 #ifdef AUDIO
     { "/call",      cmd_call              },


### PR DESCRIPTION
So the xdg-open command will fire if I call it *before* the download, but not after. Any ideas what's going on? I can see that the code got there via the debugging line, but it doesn't seem to do anything.