### PR TITLE
feat: message line padding configuration

### DIFF
--- a/misc/toxic.conf.example
+++ b/misc/toxic.conf.example
@@ -82,6 +82,10 @@ ui = {
   // time in milliseconds to display a notification
   notification_timeout=6000;
 
+  // true to pad every wrapped line of a message with enough spaces to
+  // align it to the beginning of the first line
+  line_padding=true;
+
   // Indicator for display when someone connects or joins a group
   line_join="-->";
 

--- a/src/line_info.c
+++ b/src/line_info.c
@@ -227,7 +227,7 @@ static unsigned int newline_count(const wchar_t *s)
  * Return 0 on success.
  * Return -1 if not all characters in line's message were printed to screen.
  */
-static int print_wrap(WINDOW *win, struct line_info *line, int max_x, int max_y)
+static int print_wrap(WINDOW *win, struct line_info *line, const Client_Config *c_config, int max_x, int max_y)
 {
     const wchar_t *msg = line->msg;
     uint16_t length = line->msg_width;
@@ -300,6 +300,10 @@ static int print_wrap(WINDOW *win, struct line_info *line, int max_x, int max_y)
             msg += x_limit;
             length -= x_limit;
         }
+
+		if (c_config && !c_config->line_padding) {
+			x_limit = max_x; // stop adding column padding for rest of message
+		}
 
         // Add padding to the start of the next line
         if (win && x_limit < max_x) {
@@ -374,7 +378,7 @@ static void line_info_init_line(ToxWindow *self, struct line_info *line)
     const int max_y = y2 - CHATBOX_HEIGHT - WINDOW_BAR_HEIGHT;
     const int max_x = self->show_peerlist ? x2 - 1 - SIDEBAR_WIDTH : x2;
 
-    print_wrap(NULL, line, max_x, max_y);
+    print_wrap(NULL, line, NULL, max_x, max_y);
 }
 
 /*
@@ -681,7 +685,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                     wattron(win, COLOR_PAIR(RED));
                 }
 
-                print_wrap(win, line, max_x, max_y);
+                print_wrap(win, line, c_config, max_x, max_y);
 
                 if (line->msg[0] == L'>') {
                     wattroff(win, COLOR_PAIR(GREEN));
@@ -714,7 +718,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                     wattron(win, COLOR_PAIR(RED));
                 }
 
-                print_wrap(win, line, max_x, max_y);
+                print_wrap(win, line, c_config, max_x, max_y);
 
                 if (line->msg[0] == '>') {
                     wattroff(win, COLOR_PAIR(GREEN));
@@ -739,7 +743,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
 
                 wattron(win, COLOR_PAIR(YELLOW));
                 wprintw(win, "%s %s ", c_config->line_normal, line->name1);
-                print_wrap(win, line, max_x, max_y);
+                print_wrap(win, line, c_config, max_x, max_y);
                 wattroff(win, COLOR_PAIR(YELLOW));
 
                 waddch(win, '\n');
@@ -761,7 +765,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                     wattron(win, COLOR_PAIR(line->colour));
                 }
 
-                print_wrap(win, line, max_x, max_y);
+                print_wrap(win, line, c_config, max_x, max_y);
                 waddch(win, '\n');
 
                 if (line->bold) {
@@ -781,7 +785,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                 wattroff(win, COLOR_PAIR(GREEN));
 
                 if (line->msg[0] != L'\0') {
-                    print_wrap(win, line, max_x, max_y);
+					print_wrap(win, line, c_config, max_x, max_y);
                 }
 
                 waddch(win, '\n');
@@ -800,7 +804,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                 wprintw(win, "%s ", line->name1);
                 wattroff(win, A_BOLD);
 
-                print_wrap(win, line, max_x, max_y);
+				print_wrap(win, line, c_config, max_x, max_y);
                 waddch(win, '\n');
 
                 wattroff(win, COLOR_PAIR(line->colour));
@@ -820,7 +824,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                 wprintw(win, "%s ", line->name1);
                 wattroff(win, A_BOLD);
 
-                print_wrap(win, line, max_x, max_y);
+				print_wrap(win, line, c_config, max_x, max_y);
                 waddch(win, '\n');
 
                 wattroff(win, COLOR_PAIR(line->colour));
@@ -839,7 +843,7 @@ void line_info_print(ToxWindow *self, const Client_Config *c_config)
                 wprintw(win, "%s", line->name1);
                 wattroff(win, A_BOLD);
 
-                print_wrap(win, line, max_x, max_y);
+				print_wrap(win, line, c_config, max_x, max_y);
 
                 wattron(win, A_BOLD);
                 wprintw(win, "%s\n", line->name2);

--- a/src/settings.c
+++ b/src/settings.c
@@ -65,6 +65,7 @@ static struct ui_strings {
     const char *nodeslist_update_freq;
     const char *autosave_freq;
 
+    const char *line_padding;
     const char *line_join;
     const char *line_quit;
     const char *line_alert;
@@ -102,6 +103,7 @@ static struct ui_strings {
     "show_group_connection_msg",
     "nodeslist_update_freq",
     "autosave_freq",
+    "line_padding",
     "line_join",
     "line_quit",
     "line_alert",
@@ -141,6 +143,7 @@ static void ui_defaults(Client_Config *settings)
     settings->nodeslist_update_freq = 1;
     settings->autosave_freq = 600;
 
+	settings->line_padding = true;
     snprintf(settings->line_join, LINE_HINT_MAX + 1, "%s", LINE_JOIN);
     snprintf(settings->line_quit, LINE_HINT_MAX + 1, "%s", LINE_QUIT);
     snprintf(settings->line_alert, LINE_HINT_MAX + 1, "%s", LINE_ALERT);
@@ -747,6 +750,10 @@ int settings_load_main(Client_Config *s, const Run_Options *run_opts)
         config_setting_lookup_int(setting, ui_strings.notification_timeout, &s->notification_timeout);
         config_setting_lookup_int(setting, ui_strings.nodeslist_update_freq, &s->nodeslist_update_freq);
         config_setting_lookup_int(setting, ui_strings.autosave_freq, &s->autosave_freq);
+
+        if (config_setting_lookup_bool(setting, ui_strings.line_padding, &bool_val)) {
+            s->line_padding = bool_val != 0;
+        }
 
         if (config_setting_lookup_string(setting, ui_strings.line_join, &str)) {
             snprintf(s->line_join, sizeof(s->line_join), "%s", str);

--- a/src/settings.h
+++ b/src/settings.h
@@ -48,6 +48,7 @@ typedef struct Client_Config {
     int nodeslist_update_freq;  /* <= 0 to disable updates */
     int autosave_freq; /* <= 0 to disable autosave */
 
+	bool line_padding;
     char line_join[LINE_HINT_MAX + 1];
     char line_quit[LINE_HINT_MAX + 1];
     char line_alert[LINE_HINT_MAX + 1];


### PR DESCRIPTION
Introduces new `line_padding` config option, which has a default value of `true` to correspond with the existing line padding behavior added in 8e84ac5.

When set to `false` a message exceeding the width of the window will be wrapped into new lines without an `x_start` number of blanks being printed first. Setting `x_limit` to `max_x` to prevent column padding is precedented by the existing `newline_idx >= 0` block.

Example of the behavior with `line_padding=true`:
```
00:00 - Toxic User: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                    Integer neque metus, lacinia quis magna ut, laoreet magna.
00:00 - User2: Nam suscipit faucibus justo, ut malesuada neque aliquet at...
               This text is misaligned with a message from any user with
               a user name of differing length.
```

Example of the behavior with `line_padding=false`:
```
00:00 - Toxic User: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
Integer neque metus, lacinia quis magna ut, laoreet magna.
00:00 - User2: Nam suscipit faucibus justo, ut malesuada neque aliquet at...
This text is always aligned with the first column of the window.
```

This option also allows long URLs to be copied without the padding being copied along with them, thereby breaking the URL and requiring manual intervention.

A `Client_Config` pointer parameter has been added to `print_wrap` because various other routines in the same interface already accept one, as well as to make future text wrapping configuration options easier to implement, should someone desire to.